### PR TITLE
Fix _valid() method

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -449,7 +449,7 @@ module.exports = function () {
     function _valid(file) {
         var error;
 
-        if (this.options.extensions.indexOf(file.extension) < 0) {
+        if (this.options.extensions && this.options.extensions.indexOf(file.extension) < 0) {
             error = {
                 file: file,
                 code: 'file-extension',


### PR DESCRIPTION
Fix method according to documentation.
Currently this method will fail with the error `this.options.extensions.indexOf is not a function` if property `extensions` is set to `false`.