### PR TITLE
Updated _valid() function

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -457,7 +457,7 @@ module.exports = function () {
             };
         }
 
-        else if (file.size > this.options.maxSizePerFile) {
+        else if (this.options.maxSizePerFile > 0 && file.size > this.options.maxSizePerFile) {
             error = {
                 file: file,
                 code: 'file-max-size',


### PR DESCRIPTION
Allow `maxSizePerFile` to be zero or less to allow unlimited file size.